### PR TITLE
Fix SQL syntax error on MariaDB 10.2 (#5774)

### DIFF
--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -481,7 +481,7 @@ class rcube_contacts extends rcube_addressbook
 
         // count contacts for this user
         $sql_result = $this->db->query(
-            "SELECT COUNT(c.`contact_id`) AS rows".
+            "SELECT COUNT(c.`contact_id`) AS cnt".
             " FROM " . $this->db->table_name($this->db_name, true) . " AS c".
                 $join.
             " WHERE c.`del` <> 1".
@@ -494,7 +494,7 @@ class rcube_contacts extends rcube_addressbook
 
         $sql_arr = $this->db->fetch_assoc($sql_result);
 
-        $this->cache['count'] = (int) $sql_arr['rows'];
+        $this->cache['count'] = (int) $sql_arr['cnt'];
 
         return $this->cache['count'];
     }


### PR DESCRIPTION
Backported from 1.3 release to the 1.1 LTS release.